### PR TITLE
テストコードでNavigationEntryの数を検証する機能を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,272 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## プロジェクト概要
+
+flutter_typed_navigationは、型安全なナビゲーションとRiverpod状態管理を統合したFlutterプラグインフレームワークです。
+
+## プロジェクト構造
+
+```
+flutter_typed_navigation/
+├── lib/                        # メインプラグインコード
+│   ├── flutter_typed_navigation.dart
+│   └── src/                    # コア実装
+│       ├── navigation_service.dart          # NavigationServiceインターフェース
+│       ├── internal_navigation_service.dart # Riverpod Notifier実装
+│       ├── navigation_router_delegate.dart  # Flutterルーターデリゲート
+│       ├── navigation_entry.dart            # 階層型ナビゲーションデータ構造
+│       ├── navigation_segment.dart          # ナビゲーション操作設定
+│       ├── navigation_state.dart            # イミュータブル状態管理
+│       ├── absolute_navigation_builder.dart # 絶対パスナビゲーション構築
+│       ├── relative_navigation_builder.dart # 相対パスナビゲーション構築
+│       ├── view_registry.dart               # ViewModelとView登録システム
+│       ├── viewmodel_core.dart              # ViewModelライフサイクル管理
+│       └── tab_base_widget.dart             # タブベースナビゲーション基底
+├── example/                    # デモンストレーション用サンプルアプリ
+│   ├── lib/
+│   │   ├── features/           # 機能別モジュール
+│   │   │   ├── home/          # ホーム機能
+│   │   │   ├── modal/         # モーダル機能
+│   │   │   ├── settings/      # 設定機能
+│   │   │   └── tab_root/      # タブルート機能
+│   │   └── main.dart          # アプリエントリーポイント
+│   └── pubspec.yaml
+├── test/                      # 単体テスト
+│   ├── mocks/                 # テスト用モッククラス
+│   │   ├── mock_viewmodels/   # MockViewModelクラス群
+│   │   └── mock_screens/      # MockScreenクラス群
+│   └── navigation/            # ナビゲーション機能テスト
+└── pubspec.yaml
+```
+
+## 開発コマンド
+
+### 基本セットアップ
+```bash
+# 依存関係の取得
+flutter pub get
+
+# サンプルアプリの依存関係も取得
+cd example && flutter pub get && cd ..
+```
+
+### コード生成（必須）
+Riverpodの`@riverpod`アノテーションとFreezedの`@freezed`を使用しているため、コード生成が必要です。
+
+```bash
+# 1. プラグインレベルでのコード生成（テスト用モック含む）
+dart run build_runner build --delete-conflicting-outputs
+
+# 2. サンプルアプリレベルでのコード生成
+cd example
+dart run build_runner build --delete-conflicting-outputs
+cd ..
+
+# 開発時はウォッチモードが便利
+dart run build_runner watch --delete-conflicting-outputs
+```
+
+### テスト実行
+```bash
+# 全テスト実行
+flutter test
+
+# 特定テスト実行
+flutter test test/navigation/absolute_navigation_test.dart
+flutter test test/navigation/relative_navigation_test.dart
+
+# カバレッジ付きテスト
+flutter test --coverage
+```
+
+### サンプルアプリ実行
+```bash
+cd example
+flutter run
+
+# プラットフォーム指定
+flutter run -d chrome    # Web
+flutter run -d macos     # macOS
+```
+
+### コード品質チェック
+```bash
+# 静的解析
+flutter analyze
+
+# フォーマット
+dart format .
+
+# フォーマット確認（CI用）
+dart format --set-exit-if-changed .
+```
+
+## アーキテクチャ
+
+### 3層階層ナビゲーション構造
+```
+ModalStack (List<NavigationEntry>)     // モーダル階層管理
+├── NavigatorStack (List<PageEntry>)   // ページスタック管理
+    └── TabStack (List<NavigatorEntry>) // タブコンテナ管理
+```
+
+### 主要コンポーネント
+
+#### NavigationService
+- **抽象インターフェース**: `navigation_service.dart`
+- **実装クラス**: `internal_navigation_service.dart` (Riverpod Notifier)
+- **ルーターデリゲート**: `navigation_router_delegate.dart`
+
+#### ビルダーパターン
+- **AbsoluteNavigationBuilder**: 完全に新しいナビゲーションスタック構築
+- **RelativeNavigationBuilder**: 現在のスタックに対する相対的な操作
+
+#### 登録システム
+- **ViewRegistry**: ViewModelとViewの型安全な登録
+- **ViewModelCore**: ライフサイクル管理ミックスイン
+
+### MVVMパターン
+
+#### ViewModel実装
+```dart
+@riverpod
+class ExampleViewModel extends _$ExampleViewModel with ViewModelCore {
+  @override
+  void build() {}
+
+  @override
+  void onActive() {
+    // ページアクティブ時の処理
+  }
+
+  @override
+  void onInActive() {
+    // ページ非アクティブ時の処理
+  }
+}
+```
+
+#### Screen実装
+```dart
+class ExampleScreen extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final viewModel = ref.watch(exampleViewModelProvider.notifier);
+    // UI実装
+  }
+}
+```
+
+#### 登録（main.dart）
+```dart
+navigationService.register((registry) {
+  registry
+    .register<ExampleViewModel>(
+      exampleViewModelProvider.notifier,
+      () => const ExampleScreen()
+    )
+    .registerWithParameter<ParamViewModel>(
+      (p) => paramViewModelProvider(p).notifier,
+      (p) => ParamScreen(p)
+    );
+});
+```
+
+## ナビゲーション使用例
+
+### 基本遷移
+```dart
+// 相対ナビゲーション
+await navigationService
+  .createRelativeBuilder()
+  .addPage<HomeViewModel>()
+  .navigate();
+```
+
+### パラメータ付き遷移
+```dart
+await navigationService
+  .createRelativeBuilder()
+  .addPage<DetailViewModel>(param: DetailParam('data'))
+  .navigate();
+```
+
+### 結果取得遷移
+```dart
+final result = await navigationService
+  .createRelativeBuilder()
+  .addPage<ResultViewModel>()
+  .navigateResult<String>();
+```
+
+### モーダル表示
+```dart
+// ボトムシート
+await navigationService.showBottomSheet<SheetViewModel>();
+
+// 結果取得ボトムシート
+final result = await navigationService
+  .showBottomSheetResult<SheetResultViewModel, String>();
+```
+
+### タブナビゲーション
+```dart
+await navigationService
+  .createRelativeBuilder()
+  .addTabPage<TabRootViewModel>((tabBuilder) {
+    tabBuilder
+      .addNavigator((navBuilder) {
+        navBuilder.addPage<HomeViewModel>();
+      }, isBuild: false)
+      .addNavigator((navBuilder) {
+        navBuilder.addPage<SettingsViewModel>();
+      }, isBuild: false);
+  }, selectedIndex: 0)
+  .navigate();
+```
+
+## テスト戦略
+
+### テスト構成
+- **Mock Classes**: `test/mocks/` にViewModelとScreenのモッククラス
+- **Navigation Tests**: `test/navigation/` に階層ナビゲーションテスト
+- **Base Test**: `test/navigation/navigation_test_base.dart` でテスト基盤
+
+### 主要テストケース
+- **Absolute Navigation**: 絶対パスナビゲーション
+- **Relative Navigation**: 相対パスナビゲーション
+- **Result Navigation**: 結果取得ナビゲーション
+- **Lifecycle Management**: ViewModelライフサイクル管理
+
+## 重要な開発ルール
+
+### コード生成の実行順序
+1. **プラグインレベル**: `dart run build_runner build --delete-conflicting-outputs`
+2. **Exampleアプリレベル**: `cd example && dart run build_runner build --delete-conflicting-outputs`
+
+### ViewModelライフサイクル
+- `onActiveFirst()`: 初回アクティブ化時
+- `onActive()`: アクティブ化時
+- `onInActive()`: 非アクティブ化時
+- `onPaused()`: アプリ一時停止時
+- `onResumed()`: アプリ復帰時
+
+### パフォーマンス最適化
+- `isBuild: false`による遅延描画
+- 型安全なパラメータ受け渡し
+- 効率的なページキャッシュ管理
+
+## 依存関係
+
+### 主要依存関係
+- **flutter_riverpod**: 状態管理
+- **riverpod_annotation**: Riverpodアノテーション
+- **freezed_annotation**: イミュータブルクラス生成
+
+### 開発依存関係
+- **riverpod_generator**: コード生成
+- **build_runner**: ビルドツール
+- **freezed**: イミュータブルクラス生成
+- **mockito**: テスト用モック生成

--- a/test/navigation/absolute_navigation_test.dart
+++ b/test/navigation/absolute_navigation_test.dart
@@ -28,6 +28,9 @@ void main() {
           .text('MockAStateInit')
           .shouldBe(findsOneWidget, reason: 'MockAStateInitが表示されていることを確認');
 
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つ');
+
       final vm = base.assertPageLifecycle<MockAViewModel>(
           ['build', 'onActiveFirst', 'onActive', 'onPaused', 'onResumed']);
       vm.isActive.shouldBe(true, reason: '1ページのみなので常にアクティブ');
@@ -46,6 +49,9 @@ void main() {
 
       find.text('MockBStateInit bParam').shouldBe(findsOneWidget,
           reason: 'Build後のStateの状態の反映とパラメータが渡されていることを確認');
+
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はBの1つ');
 
       final vm = base.assertPageLifecycle<MockBViewModel>(
           ['build', 'onActiveFirst', 'onActive', 'onPaused', 'onResumed']);
@@ -71,6 +77,9 @@ void main() {
           .text('MockBStateInit bParam', skipOffstage: false)
           .shouldBe(findsOneWidget, reason: 'MockBStateInitが表示されていることを確認');
 
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(2, reason: 'Navigatorの子要素はA,Bの2つ');
+
       final vmA = base.assertPageLifecycle<MockAViewModel>(
           ['build', 'onPaused', 'onResumed']);
       vmA.isActive.shouldBe(false, reason: '下層なので非アクティブ');
@@ -84,6 +93,9 @@ void main() {
       // 戻る
       base.navigationService.goBack();
       await tester.pumpAndSettle(Duration(milliseconds: 100));
+
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つに戻った');
 
       vmB.isDestroyed.shouldBeTrue(reason: '破棄対象になった');
 
@@ -122,6 +134,9 @@ void main() {
           .text('MockBStateInit bParam', skipOffstage: false)
           .shouldBe(findsOneWidget, reason: 'MockBStateInitが表示されていることを確認');
 
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(2, reason: 'Navigatorの子要素はA,Bの2つ（遅延ロードでも構造は同じ）');
+
       base
           .isVmExist<MockAViewModel>()
           .shouldBeFalse(reason: 'MockAViewModelが存在しないことを確認');
@@ -134,6 +149,9 @@ void main() {
       // 戻る
       base.navigationService.goBack();
       await tester.pumpAndSettle(Duration(milliseconds: 100));
+
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つに戻った');
 
       vmB.isDestroyed.shouldBeTrue(reason: '破棄対象になった');
 
@@ -174,6 +192,11 @@ void main() {
         .text('MockCStateInit', skipOffstage: false)
         .shouldBe(findsOneWidget, reason: 'MockCStateInitが表示されていることを確認');
 
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getTabEntry(0).children.length.shouldBe(2, reason: 'Tabは2つ');
+      base.getNavigatorEntryInTab(0, 0).children.length.shouldBe(2, reason: 'Tabの子要素はA,Bの2つ');
+      base.getNavigatorEntryInTab(0, 1).children.length.shouldBe(1, reason: 'Tabの子要素はCの1つ');
+
       final vmA = base.assertPageLifecycle<MockAViewModel>(
           ['build', 'onPaused', 'onResumed']);
       vmA.isActive.shouldBeFalse(reason: '下層なので非アクティブ');
@@ -193,6 +216,9 @@ void main() {
       base.navigationService.changeTab(0);
       await tester.pumpAndSettle(Duration(milliseconds: 100));
 
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getTabEntry(0).children.length.shouldBe(2, reason: 'Tabは2つ');
+
       base.assertPageLifecycle<MockBViewModel>(['onActiveFirst', 'onActive']);
       vmB.isActive.shouldBeTrue(reason: 'カレントページになったのでアクティブ');
       base.assertPageLifecycle<MockCViewModel>(['onInActive']);
@@ -205,6 +231,10 @@ void main() {
       // 戻る
       base.navigationService.goBack();
       await tester.pumpAndSettle(Duration(milliseconds: 100));
+
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getTabEntry(0).children.length.shouldBe(2, reason: 'Tabは2つ');
+      base.getNavigatorEntryInTab(0, 0).children.length.shouldBe(1, reason: 'Tabの子要素はAの1つに戻った');
 
       vmB.isDestroyed.shouldBeTrue(reason: '破棄対象になった');
 
@@ -248,6 +278,11 @@ void main() {
         .text('MockCStateInit', skipOffstage: false)
         .shouldBe(findsOneWidget, reason: 'MockCStateInitが表示されていることを確認');
 
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getTabEntry(0).children.length.shouldBe(2, reason: 'Tabは2つ');
+      base.getNavigatorEntryInTab(0, 0).children.length.shouldBe(2, reason: 'Tabの子要素はA,Bの2つ（遅延ロードでも構造は同じ）');
+      base.getNavigatorEntryInTab(0, 1).children.length.shouldBe(1, reason: 'Tabの子要素はCの1つ');
+
       base.isVmExist<MockAViewModel>().shouldBeFalse(reason: 'MockAViewModelが存在しないことを確認');
       base.isVmExist<MockBViewModel>().shouldBeFalse(reason: 'MockBViewModelが存在しないことを確認');
       
@@ -265,6 +300,9 @@ void main() {
       // タブを切り替える
       base.navigationService.changeTab(0);
       await tester.pumpAndSettle(Duration(milliseconds: 100));
+
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getTabEntry(0).children.length.shouldBe(2, reason: 'Tabは2つ');
 
       base.isVmExist<MockAViewModel>().shouldBeFalse(reason: 'MockAViewModelが存在しないことを確認');
       // 遅延ロードによるMockBのビルドが走る
@@ -284,6 +322,10 @@ void main() {
       // 戻る
       base.navigationService.goBack();
       await tester.pumpAndSettle(Duration(milliseconds: 100));
+
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getTabEntry(0).children.length.shouldBe(2, reason: 'Tabは2つ');
+      base.getNavigatorEntryInTab(0, 0).children.length.shouldBe(1, reason: 'Tabの子要素はAの1つに戻った');
 
       vmB.isDestroyed.shouldBeTrue(reason: '破棄対象になった');
 
@@ -320,6 +362,10 @@ void main() {
         .text('MockBStateInit bParam', skipOffstage: false)
         .shouldBe(findsOneWidget, reason: 'MockBStateInitが表示されていることを確認');
 
+      base.modalStack.length.shouldBe(2, reason: 'Modalスタックは2つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つ');
+      base.getNavigatorEntry(1).children.length.shouldBe(1, reason: 'Navigatorの子要素はBの1つ');
+
       final vmA = base.assertPageLifecycle<MockAViewModel>(
           ['build', 'onPaused', 'onResumed']);
       vmA.isActive.shouldBeFalse(reason: '下層なので非アクティブ');
@@ -333,6 +379,9 @@ void main() {
       // モーダルを閉じる
       base.navigationService.closeModal();
       await tester.pumpAndSettle(Duration(milliseconds: 100));
+
+      base.modalStack.length.shouldBe(1, reason: 'モーダルが閉じられてModalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つ');
 
       base.assertPageLifecycle<MockAViewModel>(['onActiveFirst', 'onActive']);
       vmA.isActive.shouldBeTrue(reason: 'カレントページになったのでアクティブ');
@@ -364,6 +413,9 @@ void main() {
 
       await tester.pumpAndSettle(Duration(milliseconds: 100));
 
+      base.modalStack.length.shouldBe(1, reason: '絶対遷移によりModalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はCの1つ');
+
       final vmA = base.assertPageLifecycle<MockAViewModel>(['build','destroy']);
       final vmB = base.assertPageLifecycle<MockBViewModel>(['build','onActiveFirst','onActive','destroy']);
       final vmC = base.assertPageLifecycle<MockCViewModel>(['build','onActiveFirst','onActive']);
@@ -374,6 +426,9 @@ void main() {
       vmC.isDestroyed.shouldBeFalse(reason: 'まだ破棄対象ではない');
       vmC.isActive.shouldBeTrue(reason: 'カレントページなのでアクティブ');
       
+      find
+        .text('MockCStateInit', skipOffstage: false)
+        .shouldBe(findsOneWidget, reason: 'MockCStateInitが表示されていることを確認');
     });
   });
 

--- a/test/navigation/relative_navigation_test.dart
+++ b/test/navigation/relative_navigation_test.dart
@@ -21,10 +21,16 @@ void main(){
     testWidgets('Forward Backward Navigation', (WidgetTester tester) async {
       final vmA = await base.setUpHomePage(tester);
 
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つ');
+
       // MockBに遷移する
       base.navigationService.navigate<MockBViewModel>(param: MockBParameter('bParam'));
 
       await tester.pumpAndSettle(Duration(milliseconds: 100));
+
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(2, reason: 'Navigatorの子要素はA,Bの2つ');
 
       vmA.isActive.shouldBeFalse(reason: '非アクティブになった');
       vmA.isDestroyed.shouldBeFalse(reason: 'まだ破棄対象ではない');
@@ -39,6 +45,9 @@ void main(){
       base.navigationService.goBack();
       await tester.pumpAndSettle(Duration(milliseconds: 100));
 
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つに戻った');
+
       vmA.isActive.shouldBeTrue(reason: 'カレントページになったのでアクティブ');
       vmA.isDestroyed.shouldBeFalse(reason: 'まだ破棄対象ではない');
 
@@ -50,9 +59,16 @@ void main(){
     testWidgets('Forward Backward Modal Navigation', (WidgetTester tester) async {
       final vmA = await base.setUpHomePage(tester);
 
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つ');
+
       // MockBに遷移する
       base.navigationService.navigateModal<MockBViewModel>(param: MockBParameter('bParam'));
       await tester.pumpAndSettle(Duration(milliseconds: 100));
+
+      base.modalStack.length.shouldBe(2, reason: 'Modalスタックは2つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つ');
+      base.getNavigatorEntry(1).children.length.shouldBe(1, reason: 'Navigatorの子要素はBの1つ');
 
       vmA.isActive.shouldBeFalse(reason: '非アクティブになった');
       vmA.isDestroyed.shouldBeFalse(reason: 'まだ破棄対象ではない');
@@ -66,6 +82,9 @@ void main(){
       // モーダルを閉じる
       base.navigationService.closeModal();
       await tester.pumpAndSettle(Duration(milliseconds: 100));
+      
+      base.modalStack.length.shouldBe(1, reason: 'モーダルが閉じられてModalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つ');
       
       vmA.isActive.shouldBeTrue(reason: 'カレントページになったのでアクティブ');
       vmA.isDestroyed.shouldBeFalse(reason: 'まだ破棄対象ではない');
@@ -86,12 +105,18 @@ void main(){
 
       await tester.pumpAndSettle(Duration(milliseconds: 100));
 
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(3, reason: 'Navigatorの子要素はA,B,Cの3つ');
+
       final vmB = base.assertPageLifecycle<MockBViewModel>(['build','onActiveFirst','onActive','onInActive']);
       final vmC = base.assertPageLifecycle<MockCViewModel>(['build','onActiveFirst','onActive']);
 
       // ルートに戻る
       base.navigationService.goBackToRoot();
       await tester.pumpAndSettle(Duration(milliseconds: 100));
+
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つに戻った');
 
       vmB.isDestroyed.shouldBeTrue(reason: '破棄対象になった');
       vmC.isDestroyed.shouldBeTrue(reason: '破棄対象になった');
@@ -105,13 +130,23 @@ void main(){
     testWidgets('Result Navigation', (WidgetTester tester) async {
       final vmA = await base.setUpHomePage(tester);
 
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つ');
+
       final completer = Completer<String>();
       base.navigationService.navigateResult<MockBViewModel, String>(param: MockBParameter('bParam')).then((result) {
         completer.complete(result);
       });
       await tester.pumpAndSettle(Duration(milliseconds: 100));
+      
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(2, reason: 'Navigatorの子要素はA,Bの2つ');
+      
       base.navigationService.goBackResult("OK");   
       await tester.pumpAndSettle(Duration(milliseconds: 100));
+
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つに戻った');
 
       final result = await completer.future;
       result.shouldBe("OK", reason: 'goBackResultの値が取得できた');
@@ -128,13 +163,24 @@ void main(){
     testWidgets('Modal Result Navigation', (WidgetTester tester) async {
       final vmA = await base.setUpHomePage(tester);
 
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つ');
+
       final completer = Completer<String>();
       base.navigationService.navigateModalResult<MockBViewModel, String>(param: MockBParameter('bParam')).then((result) {
         completer.complete(result);
       });
       await tester.pumpAndSettle(Duration(milliseconds: 100));
+      
+      base.modalStack.length.shouldBe(2, reason: 'Modalスタックは2つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つ');
+      base.getNavigatorEntry(1).children.length.shouldBe(1, reason: 'Navigatorの子要素はBの1つ');
+      
       base.navigationService.closeModalResult("OK");
       await tester.pumpAndSettle(Duration(milliseconds: 100));
+
+      base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(1, reason: 'Navigatorの子要素はAの1つ');
 
       final result = await completer.future;
       result.shouldBe("OK", reason: 'closeModalResultの値が取得できた');
@@ -248,6 +294,8 @@ void main(){
       await tester.pumpAndSettle(Duration(milliseconds: 100));
 
       base.modalStack.length.shouldBe(2,reason: 'モーダルが1つ閉じたのでModalスタックは2つ');
+      base.getNavigatorEntry(0).children.length.shouldBe(2, reason: 'Navigatorの子要素はA,Dの2つ');
+      base.getNavigatorEntry(1).children.length.shouldBe(2, reason: 'Navigatorの子要素はE,Fの2つ');
 
       vmG.isDestroyed.shouldBeTrue(reason: '破棄対象になった');
       vmH.isDestroyed.shouldBeTrue(reason: '破棄対象になった');


### PR DESCRIPTION
## 概要
absolute_navigation_testとrelative_navigation_testにNavigationEntryのスタック数検証を追加しました。

## 変更内容
- 既存のライフサイクルログ検証に加えて、Modal/Navigator/Tabスタックの数を確認する検証を追加
- relative_navigation_testの193-198行目の実装パターンを参考に他のテストケースにも適用
- NavigationEntryの数のみを検証し、内容の詳細な検証は行わない

## テスト対象
- `absolute_navigation_test.dart`: 全てのテストケースにNavigationEntryスタック数検証を追加
- `relative_navigation_test.dart`: 既存の検証がない箇所にNavigationEntryスタック数検証を追加

## 追加された検証例
```dart
base.modalStack.length.shouldBe(1, reason: 'Modalスタックは1つ');
base.getNavigatorEntry(0).children.length.shouldBe(2, reason: 'Navigatorの子要素はA,Bの2つ');
base.getTabEntry(0).children.length.shouldBe(2, reason: 'Tabは2つ');
```

## テスト結果
全てのテストが正常に実行されることを確認済みです。

#1