### PR TITLE
モーダル遷移のアニメーションをSlideUp/SlideDownに変更

### DIFF
--- a/lib/src/navigation_page.dart
+++ b/lib/src/navigation_page.dart
@@ -1,5 +1,65 @@
 import 'package:flutter/material.dart';
 
+class _ModalPageRoute<T> extends PageRoute<T> {
+  _ModalPageRoute({
+    required this.builder,
+    required RouteSettings settings,
+  }) : super(settings: settings);
+
+  final WidgetBuilder builder;
+
+  @override
+  bool get opaque => false;
+
+  @override
+  Color? get barrierColor => Colors.black54;
+
+  @override
+  String? get barrierLabel => null;
+
+  @override
+  bool get maintainState => true;
+
+  @override
+  Duration get transitionDuration => const Duration(milliseconds: 300);
+
+  @override
+  Duration get reverseTransitionDuration => const Duration(milliseconds: 300);
+
+  @override
+  Widget buildPage(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+  ) {
+    return builder(context);
+  }
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    // SlideUp animation for modal appearance
+    const begin = Offset(0.0, 1.0); // Start from bottom
+    const end = Offset.zero; // End at center
+    const curve = Curves.easeInOut;
+
+    final tween = Tween(begin: begin, end: end).chain(
+      CurveTween(curve: curve),
+    );
+
+    final offsetAnimation = animation.drive(tween);
+
+    return SlideTransition(
+      position: offsetAnimation,
+      child: child,
+    );
+  }
+}
+
 class EmptyPage extends MaterialPage {
   const EmptyPage({super.key}) : super(child: const SizedBox.shrink());
 
@@ -39,7 +99,7 @@ class NavigatorPage extends MaterialPage {
 
   @override
   Route createRoute(BuildContext context) {
-    return MaterialPageRoute(
+    return _ModalPageRoute(
       settings: this,
       builder: (context) => child,
     );
@@ -57,7 +117,7 @@ class TabPage extends MaterialPage {
 
   @override
   Route createRoute(BuildContext context) {
-    return MaterialPageRoute(
+    return _ModalPageRoute(
       settings: this,
       builder: (context) => child,
     );


### PR DESCRIPTION
## Summary
NavigatorPageとTabPageのモーダル遷移において、MaterialPageRouteの代わりにカスタム_ModalPageRouteを実装し、.NET MAUI風のSlideUp/SlideDownアニメーションを追加しました。

## 変更内容
- `_ModalPageRoute`クラスを新規実装
  - SlideUpアニメーション（表示時：下から上へ）
  - SlideDownアニメーション（非表示時：上から下へ）
  - アニメーション時間：300ms
  - イージング：easeInOut
- `NavigatorPage`と`TabPage`の`createRoute`メソッドを更新
- 全テスト（23個）が正常にパス

## Test plan
- [x] 既存テストスイートの実行
- [x] NavigatorPageのモーダル遷移アニメーション確認
- [x] TabPageのモーダル遷移アニメーション確認
- [x] アニメーション性能とタイミングの検証

🤖 Generated with [Claude Code](https://claude.ai/code)

#3