### PR TITLE
CLAUDE.mdにdart format実行禁止のルールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,12 +96,28 @@ flutter run -d macos     # macOS
 # 静的解析
 flutter analyze
 
-# フォーマット
-dart format .
-
-# フォーマット確認（CI用）
-dart format --set-exit-if-changed .
+# ⚠️ 重要: dart formatは実行禁止
+# dart format .              # 実行しないこと
+# dart format --set-exit-if-changed .  # 実行しないこと
 ```
+
+### ⚠️ dart format 実行禁止
+**このプロジェクトでは dart format コマンドの実行を禁止します。**
+
+#### 理由
+- 意図しないフォーマット変更により、PRに大量の無関係な変更が混入する
+- 実際の機能変更のみをコミットに含めたいため
+- レビュー時に本質的な変更を見つけにくくなる
+
+#### 禁止対象
+- `dart format .` コマンドの直接実行
+- IDE/エディタの自動フォーマット機能の使用
+- 保存時の自動フォーマット
+
+#### コミット時の注意
+- `git diff` で変更内容を必ず確認
+- フォーマット変更が含まれている場合は、機能変更のみを選択的にコミット
+- `git add -p` を活用して部分的なステージングを行う
 
 ## アーキテクチャ
 


### PR DESCRIPTION
## Summary
意図しないフォーマット変更でPRに大量の無関係な変更が混入することを防ぐため、dart formatコマンドの実行を明示的に禁止するルールをCLAUDE.mdに追加しました。

## 変更内容
- **コード品質チェックセクションの修正**
  - `dart format` コマンドをコメントアウト
  - 実行禁止の警告を追加

- **新規セクション「⚠️ dart format 実行禁止」を追加**
  - 禁止理由の明記
  - 具体的な禁止対象の列挙
  - コミット時の注意事項

## 効果
- 今後の開発でクリーンなコミット履歴を維持
- PRレビュー時に本質的な変更に集中可能
- フォーマット変更による意図しない差分の混入を防止

## Test plan
- [x] CLAUDE.mdの内容確認
- [x] 記述内容の妥当性検証
- [x] プロジェクトルールとしての適切性確認

🤖 Generated with [Claude Code](https://claude.ai/code)