### PR TITLE
iOSでのNavigatorPageクローズアニメーションを改善

### DIFF
--- a/lib/src/navigation_page.dart
+++ b/lib/src/navigation_page.dart
@@ -1,3 +1,4 @@
+import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 
 class _ModalPageRoute<T> extends PageRoute<T> {
@@ -45,10 +46,13 @@ class _ModalPageRoute<T> extends PageRoute<T> {
     // SlideUp animation for modal appearance
     const begin = Offset(0.0, 1.0); // Start from bottom
     const end = Offset.zero; // End at center
-    const curve = Curves.easeInOut;
+    
+    // Use platform-specific curves for more natural animation
+    final curve = Platform.isIOS ? Curves.easeOut : Curves.easeInOut;
+    final reverseCurve = Platform.isIOS ? Curves.easeIn : Curves.easeInOut;
 
     final tween = Tween(begin: begin, end: end).chain(
-      CurveTween(curve: curve),
+      CurveTween(curve: animation.status == AnimationStatus.reverse ? reverseCurve : curve),
     );
 
     final offsetAnimation = animation.drive(tween);


### PR DESCRIPTION
## Summary
- iOSプラットフォームでより自然なNavigatorPageクローズアニメーション体験を提供
- プラットフォーム固有のアニメーションカーブを適用して、iOS固有の斜め左下への不自然な動きを解消

## 変更内容
- `Platform.isIOS`による条件分岐を追加
- iOS: 表示時`Curves.easeOut`、非表示時`Curves.easeIn`を使用
- Android: 既存の`Curves.easeInOut`を維持
- `dart:io`のインポートを追加

## Test plan
- [x] 静的解析（flutter analyze）で問題がないことを確認
- [x] 既存の警告・情報レベルの問題には影響しないことを確認
- [ ] iOSシミュレータでNavigatorPageの開閉アニメーションが改善されることを確認
- [ ] AndroidでのNavigatorPageアニメーションに影響がないことを確認
- [ ] TabPageのアニメーション（正常動作）に影響がないことを確認

@muak #6