### PR TITLE
絶対遷移時のアニメーションを無効化

### DIFF
--- a/lib/src/navigation_page.dart
+++ b/lib/src/navigation_page.dart
@@ -89,7 +89,9 @@ class ContentPage extends MaterialPage {
 }
 
 class NavigatorPage extends MaterialPage {
-  const NavigatorPage({required super.child, super.key});
+  final bool isAnimated;
+  
+  const NavigatorPage({required super.child, super.key, this.isAnimated = true});
 
   @override
   bool canUpdate(Page other) {
@@ -99,15 +101,24 @@ class NavigatorPage extends MaterialPage {
 
   @override
   Route createRoute(BuildContext context) {
-    return _ModalPageRoute(
-      settings: this,
-      builder: (context) => child,
-    );
+    if (isAnimated) {
+      return _ModalPageRoute(
+        settings: this,
+        builder: (context) => child,
+      );
+    } else {
+      return MaterialPageRoute(
+        settings: this,
+        builder: (context) => child,
+      );
+    }
   }
 }
 
 class TabPage extends MaterialPage {
-  const TabPage({required super.child, super.key});
+  final bool isAnimated;
+  
+  const TabPage({required super.child, super.key, this.isAnimated = true});
 
   @override
   bool canUpdate(Page other) {
@@ -117,9 +128,16 @@ class TabPage extends MaterialPage {
 
   @override
   Route createRoute(BuildContext context) {
-    return _ModalPageRoute(
-      settings: this,
-      builder: (context) => child,
-    );
+    if (isAnimated) {
+      return _ModalPageRoute(
+        settings: this,
+        builder: (context) => child,
+      );
+    } else {
+      return MaterialPageRoute(
+        settings: this,
+        builder: (context) => child,
+      );
+    }
   }
 }

--- a/lib/src/navigation_router_delegate.dart
+++ b/lib/src/navigation_router_delegate.dart
@@ -196,7 +196,14 @@ class NavigationRouterDelegate extends RouterDelegate<Empty>
     // タブ本体ページを生成
     final tabPageValue = _getTabPageValue(entry, tabConfigState);
 
-    return TabPage(key: ValueKey(entry.pageId), child: tabPageValue.view);
+    // shouldClearCacheがtrueの場合はアニメーションを無効にする
+    final shouldClearCache = ref.read(navigationServiceStateProvider).shouldClearCache;
+    
+    return TabPage(
+      key: ValueKey(entry.pageId), 
+      child: tabPageValue.view,
+      isAnimated: !shouldClearCache,
+    );
   }
 
   Widget _buildNavigator(NavigatorEntry entry, {bool isTab = false}) {
@@ -230,9 +237,14 @@ class NavigationRouterDelegate extends RouterDelegate<Empty>
     if (entry.isLazy) {
       return EmptyPage(key: ValueKey(entry.pageId));
     }
+    
+    // shouldClearCacheがtrueの場合はアニメーションを無効にする
+    final shouldClearCache = ref.read(navigationServiceStateProvider).shouldClearCache;
+    
     return NavigatorPage(
       key: ValueKey(entry.pageId),
       child: _buildNavigator(entry),
+      isAnimated: !shouldClearCache,
     );
   }
 


### PR DESCRIPTION
@muak

## 概要
絶対遷移（`navigationService.createAbsoluteBuilder().setRoutes()`）時に開始アニメーションを無効化する機能を実装しました。

## 変更内容
- NavigatorPageとTabPageに`isAnimated`プロパティを追加（デフォルト: true）
- `isAnimated`がfalseの場合は`MaterialPageRoute`を使用してアニメーションを無効化
- `NavigationState.shouldClearCache`がtrueの場合（絶対遷移時）に`isAnimated = false`を自動設定

## 実装詳細
1. **NavigatorPage/TabPageの拡張**
   - `isAnimated`パラメータを追加
   - アニメーション有効時は従来の`_ModalPageRoute`を使用
   - アニメーション無効時は`MaterialPageRoute`を使用

2. **NavigationRouterDelegateの修正**  
   - `_buildNavigatorPage()`と`_buildTabPage()`で`shouldClearCache`を確認
   - 絶対遷移時は`isAnimated: false`を設定

## テスト結果
- 全てのテストが成功
- 既存機能への影響なし

#7