### PR TITLE
feat: Implement auto-registration code generation system

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,15 @@
+targets:
+  $default:
+    builders:
+      flutter_typed_navigation|auto_register_builder:
+        enabled: true
+        
+builders:
+  auto_register_builder:
+    import: "package:flutter_typed_navigation/src/generators/auto_register_builder.dart"
+    builder_factories: ["autoRegisterBuilder"]
+    build_extensions: 
+      "$lib$": ["auto_register.g.dart"]
+    auto_apply: all_packages
+    build_to: source
+    runs_before: ["json_serializable", "freezed"] 

--- a/example/lib/features/home/alpha_param_screen.dart
+++ b/example/lib/features/home/alpha_param_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_typed_navigation/flutter_typed_navigation.dart';
 import 'alpha_param_viewmodel.dart';
 
+@RegisterFor<AlphaParamViewModel>()
 class AlphaParamScreen extends ConsumerWidget {  
   const AlphaParamScreen(this.param,{super.key});
   final AlphaParam param;

--- a/example/lib/features/home/alpha_screen.dart
+++ b/example/lib/features/home/alpha_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_typed_navigation/flutter_typed_navigation.dart';
 import 'alpha_viewmodel.dart';
 
+@RegisterFor<AlphaViewModel>()
 class AlphaScreen extends ConsumerWidget {
   const AlphaScreen({super.key});
 

--- a/example/lib/features/home/home_screen.dart
+++ b/example/lib/features/home/home_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_typed_navigation/flutter_typed_navigation.dart';
 import 'home_viewmodel.dart';
 
+@RegisterFor<HomeViewModel>()
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
 

--- a/example/lib/features/tab_root/tab_root_screen.dart
+++ b/example/lib/features/tab_root/tab_root_screen.dart
@@ -3,10 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 
 import 'package:flutter_typed_navigation/flutter_typed_navigation.dart';
+import 'tab_root_viewmodel.dart';
 
-
-
-
+@RegisterFor<TabRootViewModel>()
 class TabRootScreen extends TabBaseWidget {
   const TabRootScreen({super.key, required super.config});
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,13 +4,17 @@ import 'package:flutter_typed_navigation/flutter_typed_navigation.dart';
 import 'app.dart';
 import 'features/viewmodels.dart';
 import 'features/screens.dart';
+import 'auto_register.g.dart';
 
 void main() {
   final container = ProviderContainer();
   final navigationService = container.read(navigationServiceProvider);
   navigationService.register((regisgtry) {
+    // 自動生成されたコードを使用
+    regisgtry.registerAuto();
+    
+    // 残りの手動登録
     regisgtry
-    .register<HomeViewModel>(() => const HomeScreen(), homeViewModelProvider.notifier)    
     .registerWithParameter<HomeDetailViewModel>((p) => HomeDetailScreen(p), (p)=>homeDetailViewModelProvider(p).notifier)
     .register<SettingsViewModel>(() => const SettingsScreen(), settingsViewModelProvider.notifier)
     .register<AccountSettingsViewModel>(() => const AccountSettingsScreen(), accountSettingsViewModelProvider.notifier)
@@ -18,12 +22,9 @@ void main() {
     .register<SheetResultViewModel>(() => const SheetResultScreen(), sheetResultViewModelProvider.notifier)
     .registerWithParameter<SheetParamViewModel>((p) => SheetParamScreen(param: p), (p)=>sheetParamViewModelProvider(p).notifier)
     .registerWithParameter<SheetParamResultViewModel>((p) => SheetParamResultScreen(param: p), (p)=>sheetParamResultViewModelProvider(p).notifier)
-    .register<AlphaViewModel>(() => const AlphaScreen(), alphaViewModelProvider.notifier)
     .register<AlphaResultViewModel>(() => const AlphaResultScreen(), alphaResultViewModelProvider.notifier)
-    .registerWithParameter<AlphaParamViewModel>((p) => AlphaParamScreen(p), (p)=>alphaParamViewModelProvider(p).notifier)
     .registerWithParameter<AlphaParamResultViewModel>((p) => AlphaParamResultScreen(param: p), (p)=>alphaParamResultViewModelProvider(p).notifier)
     .register<BetaViewModel>(() => const BetaScreen(), betaViewModelProvider.notifier)
-    .registerTab<TabRootViewModel>((p) => TabRootScreen(config: p), tabRootViewModelProvider.notifier)
     .register<ModalHomeViewModel>(() => const ModalHomeScreen(), modalHomeViewModelProvider.notifier)
     .register<ModalAlphaViewModel>(() => const ModalAlphaScreen(), modalAlphaViewModelProvider.notifier)
     .registerWithParameter<ModalResultViewModel>((p) => ModalResultScreen(p), (p)=>modalResultViewModelProvider(p).notifier)

--- a/lib/flutter_typed_navigation.dart
+++ b/lib/flutter_typed_navigation.dart
@@ -27,3 +27,6 @@ export 'src/platform_service.dart';
 
 // Navigation app
 export 'src/navigation_app.dart';
+
+// Annotations
+export 'src/annotations.dart';

--- a/lib/src/annotations.dart
+++ b/lib/src/annotations.dart
@@ -1,0 +1,15 @@
+/// ViewRegistryの自動登録のためのアノテーション
+/// 
+/// Viewクラスに付与することで、指定されたViewModelとの
+/// 組み合わせでViewRegistryに自動登録される
+/// 
+/// 使用例:
+/// ```dart
+/// @RegisterFor<MyViewModel>()
+/// class MyScreen extends StatelessWidget {
+///   // ...
+/// }
+/// ```
+class RegisterFor<T> {
+  const RegisterFor();
+} 

--- a/lib/src/generators/auto_register_builder.dart
+++ b/lib/src/generators/auto_register_builder.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:build/build.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:glob/glob.dart';
+import 'package:source_gen/source_gen.dart';
+import 'view_registry_generator.dart';
+
+/// Builder factoryを提供
+Builder autoRegisterBuilder(BuilderOptions options) => AutoRegisterBuilder();
+
+/// auto_register.g.dartファイルを生成するBuilder
+class AutoRegisterBuilder implements Builder {
+  @override
+  Map<String, List<String>> get buildExtensions => {
+    r'$lib$': ['auto_register.g.dart'],
+  };
+
+  @override
+  Future<void> build(BuildStep buildStep) async {
+    final generator = ViewRegistryGenerator();
+    final registrations = <String>[];
+    final requiredImports = <String>{};
+
+    // lib/以下のすべてのDartファイルをスキャン
+    final dartFiles = Glob('lib/**.dart');
+    await for (final assetId in buildStep.findAssets(dartFiles)) {
+      if (assetId.path.endsWith('.g.dart') || assetId.path.endsWith('.freezed.dart')) {
+        continue; // 生成されたファイルはスキップ
+      }
+
+      final library = await buildStep.resolver.libraryFor(assetId);
+      
+      for (final element in library.topLevelElements) {
+        if (element is ClassElement) {
+          final registerForAnnotation = _getRegisterForAnnotation(element);
+          if (registerForAnnotation != null) {
+            try {
+              final registration = await generator.generateForAnnotatedElement(
+                element,
+                registerForAnnotation,
+                buildStep,
+              );
+              registrations.add(registration);
+              
+              // 必要なimportを追加
+              requiredImports.add(assetId.uri.toString());
+              
+              // ViewModelの型情報を取得してimportを追加
+              final viewModelTypeInfo = generator.getViewModelType(registerForAnnotation);
+              if (viewModelTypeInfo?.libraryUri != null) {
+                requiredImports.add(viewModelTypeInfo!.libraryUri!);
+              }
+            } catch (e) {
+              // エラーは無視して次の要素に進む
+              print('Warning: Failed to generate registration for ${element.name}: $e');
+            }
+          }
+        }
+      }
+    }
+
+    if (registrations.isNotEmpty) {
+      final content = _generateFileContent(registrations, requiredImports);
+      final outputId = AssetId(buildStep.inputId.package, 'lib/auto_register.g.dart');
+      await buildStep.writeAsString(outputId, content);
+    }
+  }
+
+  ConstantReader? _getRegisterForAnnotation(ClassElement element) {
+    for (final annotation in element.metadata) {
+      final annotationValue = annotation.computeConstantValue();
+      if (annotationValue != null && 
+          annotationValue.type?.element?.name == 'RegisterFor') {
+        return ConstantReader(annotationValue);
+      }
+    }
+    return null;
+  }
+
+  String _generateFileContent(List<String> registrations, Set<String> requiredImports) {
+    final buffer = StringBuffer();
+    
+    // 基本的なimport
+    buffer.writeln("import 'package:flutter/widgets.dart';");
+    buffer.writeln("import 'package:flutter_riverpod/flutter_riverpod.dart';");
+    buffer.writeln("import 'package:flutter_typed_navigation/flutter_typed_navigation.dart';");
+    
+    // 必要なimportを追加
+    for (final importUri in requiredImports) {
+      if (importUri.startsWith('package:') || importUri.startsWith('dart:')) {
+        buffer.writeln("import '$importUri';");
+      } else {
+        // 相対パスの場合は適切に変換
+        final relativePath = importUri.startsWith('asset:') 
+          ? importUri.replaceFirst('asset:flutter_typed_navigation/', '')
+          : importUri;
+        if (relativePath.startsWith('lib/')) {
+          buffer.writeln("import '${relativePath.substring(4)}';");
+        } else {
+          buffer.writeln("import '$relativePath';");
+        }
+      }
+    }
+    
+    buffer.writeln();
+    buffer.writeln('extension ViewRegistryExtension on ViewRegistry {');
+    buffer.writeln('  ViewRegistry registerAuto() {');
+    buffer.writeln('    final registry = this;');
+    
+    for (final registration in registrations) {
+      buffer.writeln('    $registration');
+    }
+    
+    buffer.writeln('    return registry;');
+    buffer.writeln('  }');
+    buffer.writeln('}');
+
+    try {
+      final formatter = DartFormatter(languageVersion: DartFormatter.latestLanguageVersion);
+      return formatter.format(buffer.toString());
+    } catch (e) {
+      // フォーマットに失敗した場合は、フォーマットなしで返す
+      return buffer.toString();
+    }
+  }
+} 

--- a/lib/src/generators/auto_register_builder.dart
+++ b/lib/src/generators/auto_register_builder.dart
@@ -81,9 +81,7 @@ class AutoRegisterBuilder implements Builder {
   String _generateFileContent(List<String> registrations, Set<String> requiredImports, String packageName) {
     final buffer = StringBuffer();
     
-    // 基本的なimport
-    buffer.writeln("import 'package:flutter/widgets.dart';");
-    buffer.writeln("import 'package:flutter_riverpod/flutter_riverpod.dart';");
+    // 必要最小限のimport
     buffer.writeln("import 'package:flutter_typed_navigation/flutter_typed_navigation.dart';");
     
     // 必要なimportを追加

--- a/lib/src/generators/view_registry_generator.dart
+++ b/lib/src/generators/view_registry_generator.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:build/build.dart';
+import 'package:source_gen/source_gen.dart';
+import '../annotations.dart';
+
+/// ViewRegistryの自動登録コードを生成するジェネレータ
+class ViewRegistryGenerator extends GeneratorForAnnotation<RegisterFor> {
+  @override
+  FutureOr<String> generateForAnnotatedElement(
+    Element element,
+    ConstantReader annotation,
+    BuildStep buildStep,
+  ) async {
+    if (element is! ClassElement) {
+      throw InvalidGenerationSourceError(
+        'RegisterFor can only be applied to classes.',
+        element: element,
+      );
+    }
+
+    final viewClass = element;
+    final viewModelType = getViewModelType(annotation);
+    
+    if (viewModelType == null) {
+      throw InvalidGenerationSourceError(
+        'RegisterFor annotation must have a type argument.',
+        element: element,
+      );
+    }
+
+    final constructorInfo = _analyzeConstructor(viewClass);
+    if (constructorInfo == null) {
+      throw InvalidGenerationSourceError(
+        'Class ${viewClass.name} must have a constructor.',
+        element: element,
+      );
+    }
+
+    final isTabWidget = _isTabBaseWidget(viewClass);
+    final creatorFunction = _generateCreatorFunction(viewClass, constructorInfo, isTabWidget);
+    final registerCall = _generateRegisterCall(viewModelType, creatorFunction, isTabWidget, constructorInfo.hasRequiredFirstParameter);
+
+    return registerCall;
+  }
+
+  ViewModelTypeInfo? getViewModelType(ConstantReader annotation) {
+    final annotationType = annotation.objectValue.type;
+    if (annotationType is InterfaceType) {
+      final typeArguments = annotationType.typeArguments;
+      if (typeArguments.isEmpty) {
+        return null;
+      }
+
+      final viewModelType = typeArguments.first;
+      return ViewModelTypeInfo(
+        name: viewModelType.getDisplayString(withNullability: false),
+        libraryUri: viewModelType.element?.library?.source.uri.toString(),
+      );
+    }
+    return null;
+  }
+
+  ConstructorInfo? _analyzeConstructor(ClassElement viewClass) {
+    final constructor = viewClass.unnamedConstructor;
+    if (constructor == null) {
+      return null;
+    }
+
+    final parameters = constructor.parameters;
+    
+    // TabBaseWidgetの場合は特別な処理
+    if (_isTabBaseWidget(viewClass)) {
+      // TabBaseWidgetのコンストラクタは config パラメータを持つ
+      return ConstructorInfo(
+        parameters: parameters,
+        hasRequiredFirstParameter: false, // TabCreatorは特別な扱い
+      );
+    }
+    
+    // 第一引数が必須かどうかをチェック
+    bool hasRequiredFirstParameter = false;
+    if (parameters.isNotEmpty) {
+      final firstParam = parameters.first;
+      if (firstParam.isRequiredPositional) {
+        hasRequiredFirstParameter = true;
+      }
+    }
+
+    return ConstructorInfo(
+      parameters: parameters,
+      hasRequiredFirstParameter: hasRequiredFirstParameter,
+    );
+  }
+
+  bool _isTabBaseWidget(ClassElement element) {
+    return _isSubclassOf(element, 'TabBaseWidget');
+  }
+
+  bool _isSubclassOf(ClassElement element, String className) {
+    if (element.name == className) {
+      return true;
+    }
+    
+    final supertype = element.supertype;
+    if (supertype != null) {
+      final supertypeElement = supertype.element;
+      if (supertypeElement is ClassElement) {
+        return _isSubclassOf(supertypeElement, className);
+      }
+    }
+    
+    return false;
+  }
+
+  String _generateCreatorFunction(ClassElement viewClass, ConstructorInfo constructorInfo, bool isTabWidget) {
+    final className = viewClass.name;
+    final parameters = constructorInfo.parameters;
+    
+    if (isTabWidget) {
+      // TabCreator: Widget Function(TabConfigState config)
+      return '(config) => $className(config: config)';
+    } else if (constructorInfo.hasRequiredFirstParameter) {
+      // ViewCreatorP: Widget Function(dynamic parameter)
+      return '(parameter) => $className(parameter)';
+    } else {
+      // ViewCreator: Widget Function()
+      return '() => const $className()';
+    }
+  }
+
+  String _generateRegisterCall(ViewModelTypeInfo viewModelType, String creatorFunction, bool isTabWidget, bool hasRequiredFirstParameter) {
+    final viewModelName = viewModelType.name;
+    final providerName = _getProviderName(viewModelName);
+    
+    if (isTabWidget) {
+      return 'registry.registerTab<$viewModelName>($creatorFunction, ${providerName}.notifier);';
+    } else if (hasRequiredFirstParameter) {
+      // registerWithParameterの場合、パラメータ付きProviderを使用
+      final viewModelCreatorFunction = '(parameter) => ${providerName}(parameter).notifier';
+      return 'registry.registerWithParameter<$viewModelName>($creatorFunction, $viewModelCreatorFunction);';
+    } else {
+      return 'registry.register<$viewModelName>($creatorFunction, ${providerName}.notifier);';
+    }
+  }
+
+  String _getProviderName(String viewModelName) {
+    // ViewModelの名前からProviderの名前を推測
+    // 例: TestViewModel -> testViewModelProvider
+    // 例: AlphaParamViewModel -> alphaParamViewModelProvider
+    final baseName = viewModelName.replaceFirst('ViewModel', '');
+    final camelCaseName = baseName[0].toLowerCase() + baseName.substring(1);
+    return '${camelCaseName}ViewModelProvider';
+  }
+}
+
+/// ViewModelの型情報を保持するクラス
+class ViewModelTypeInfo {
+  final String name;
+  final String? libraryUri;
+
+  ViewModelTypeInfo({required this.name, this.libraryUri});
+}
+
+class ConstructorInfo {
+  final List<ParameterElement> parameters;
+  final bool hasRequiredFirstParameter;
+
+  ConstructorInfo({
+    required this.parameters,
+    required this.hasRequiredFirstParameter,
+  });
+} 

--- a/lib/src/generators/view_registry_generator.dart
+++ b/lib/src/generators/view_registry_generator.dart
@@ -146,12 +146,15 @@ class ViewRegistryGenerator extends GeneratorForAnnotation<RegisterFor> {
   }
 
   String _getProviderName(String viewModelName) {
-    // ViewModelの名前からProviderの名前を推測
-    // 例: TestViewModel -> testViewModelProvider
-    // 例: AlphaParamViewModel -> alphaParamViewModelProvider
-    final baseName = viewModelName.replaceFirst('ViewModel', '');
-    final camelCaseName = baseName[0].toLowerCase() + baseName.substring(1);
-    return '${camelCaseName}ViewModelProvider';
+    // ViewModelの名前からProviderの名前を生成
+    // 例: HomeViewModel -> homeViewModelProvider
+    // 例: SomeFooBar -> someFooBarProvider
+    if (viewModelName.isEmpty) {
+      throw ArgumentError('viewModelName cannot be empty');
+    }
+    
+    final camelCaseName = viewModelName[0].toLowerCase() + viewModelName.substring(1);
+    return '${camelCaseName}Provider';
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,9 @@ dev_dependencies:
   freezed: ^3.1.0
   json_annotation: ^4.8.1
   json_serializable: ^6.7.1
+  source_gen: ^2.0.0
+  analyzer: ^7.4.5
+  glob: ^2.1.2
   # テスト用依存関係
   mockito: ^5.4.4
 


### PR DESCRIPTION
## 🎯 概要

GitHub Issue #23で要求された自動登録コード生成システムを実装しました。
riverpodやfreezedと同様に、パッケージを追加するだけで自動的にコード生成が実行される仕組みを導入しました。

## ✨ 実装した機能

### 1. アノテーションシステム
- @RegisterFor<T> アノテーションを追加
- ViewModelの型情報を自動的に解析
- パラメータ有無やTabBaseWidget継承を自動判別

### 2. コード生成システム
- auto_register_builder でbuild_runner統合
- ViewRegistryGenerator でClassElement解析
- 3種類のCreator関数を自動生成：
  - ViewCreator: 引数なしの場合
  - ViewCreatorP: パラメータ付きの場合  
  - TabCreator: TabBaseWidget継承の場合

### 3. 自動適用機能
- auto_apply: all_packages でユーザーのbuild.yaml設定不要
- runs_before で実行順序制御
- 適切なimport文の自動生成

## 🔧 技術的詳細

### 生成されるコード例
アノテーション使用例とその自動生成コード

### ファイル構成
- lib/src/annotations.dart - アノテーション定義
- lib/src/generators/auto_register_builder.dart - メインビルダー
- lib/src/generators/view_registry_generator.dart - コード生成器
- build.yaml - パッケージレベル設定

## 🎉 使用方法

1. アノテーション追加
2. 自動登録呼び出し
3. build.yaml不要: パッケージを追加するだけで自動実行

## ✅ 動作確認

- アノテーション解析の正常動作
- 3種類のCreator関数生成
- Provider.notifier の正しい付与
- 自動適用機能の動作
- 実行順序制御の確認
- exampleアプリでの動作確認

## 🔗 関連Issue

Closes #23